### PR TITLE
Fixed computing the scores

### DIFF
--- a/model.py
+++ b/model.py
@@ -599,7 +599,7 @@ class Model:
                 predicted_strings = [[self.index_to_target[sugg] for sugg in timestep]
                                      for timestep in predicted_indices]  # (target_length, top-k)  
                 predicted_strings = list(map(list, zip(*predicted_strings)))  # (top-k, target_length)
-                top_scores = [np.exp(np.sum(s, 0)) for s in top_scores]
+                top_scores = [np.exp(np.sum(s)) for s in zip(*top_scores)]
             else:
                 predicted_strings = [self.index_to_target[idx]
                                      for idx in predicted_indices]  # (batch, target_length)  


### PR DESCRIPTION
The variable top_scores should contains probabilities of the predictions. If we set BEAM_WIDTH = **n**, we expect to get **n** scores for the corresponding predictions. Now it works incorrect, I suggest to fix it.