### PR TITLE
fix "|" for source, targer elements

### DIFF
--- a/JavaExtractor/JPredict/src/main/java/JavaExtractor/Common/Common.java
+++ b/JavaExtractor/JPredict/src/main/java/JavaExtractor/Common/Common.java
@@ -53,8 +53,9 @@ public final class Common {
     }
 
     public static ArrayList<String> splitToSubtokens(String str1) {
-        String str2 = str1.trim();
-        return Stream.of(str2.split("(?<=[a-z])(?=[A-Z])|_|[0-9]|(?<=[A-Z])(?=[A-Z][a-z])|\\s+"))
+        String str2 = str1.replace("|", " ");
+        String str3 = str2.trim();
+        return Stream.of(str3.split("(?<=[a-z])(?=[A-Z])|_|[0-9]|(?<=[A-Z])(?=[A-Z][a-z])|\\s+"))
                 .filter(s -> s.length() > 0).map(s -> Common.normalizeName(s, Common.EmptyString))
                 .filter(s -> s.length() > 0).collect(Collectors.toCollection(ArrayList::new));
     }


### PR DESCRIPTION
When code from dataset contains string literals with `|` character in, `preprocess.sh` produces invalid output.

My dataset contains this string literal: 
```
"<!ENTITY % types \"fileset | patternset \"> <!ELEMENT project (target | taskdef | %types; | property )*> "
```
after running `JavaExtractor/extract.py` there was
```
entity|%|types|fileset|||patternset|\>|element|project|target|||taskdef|||types|||property|)*>,StrEx0|Plus1|StrEx1,element|targetelement|taskdefelement|filesetelement|patternsetelement|property
``` 
and in `<dataset-name>.histo.ori.c2s ` file there was the string like that
```
 92
project 13
root 18
```

So, this fix just replaces from source, target variables all '|' before splitting.