### PR TITLE
remove unnecessaryv variable

### DIFF
--- a/interactive_predict.py
+++ b/interactive_predict.py
@@ -2,7 +2,6 @@ from common import Common
 from extractor import Extractor
 
 SHOW_TOP_CONTEXTS = 10
-MAX_PATH_LENGTH = 8
 MAX_PATH_WIDTH = 2
 EXTRACTION_API = 'https://po3g2dx2qa.execute-api.us-east-1.amazonaws.com/production/extractmethods'
 
@@ -14,7 +13,7 @@ class InteractivePredictor:
         model.predict([])
         self.model = model
         self.config = config
-        self.path_extractor = Extractor(config, EXTRACTION_API, self.config.MAX_PATH_LENGTH, max_path_width=2)
+        self.path_extractor = Extractor(config, EXTRACTION_API, self.config.MAX_PATH_LENGTH, max_path_width=MAX_PATH_WIDTH)
 
     @staticmethod
     def read_file(input_filename):


### PR DESCRIPTION
Hello.
MAX_PATH_LENGTH is referenced from config.py in line 17 of interactive_predict.py. Therefore, MAX_PATH_LENGTH in line 5 don't need.
Also, shouldn't MAX_PATH_WIDTH in line 5 be referenced in line 17?
Please check this PR.
Thank you.